### PR TITLE
Changed to Non-Blocking form, moved int conversion so only does once,…

### DIFF
--- a/StatusWindow.py
+++ b/StatusWindow.py
@@ -2,21 +2,24 @@ import PySimpleGUI as sg
 
 
 def status_window():
-
-    sg.ChangeLookAndFeel('TealMono')  #Changes color scheme of window created
+    sg.ChangeLookAndFeel('TealMono')  # Changes color scheme of window created
     form = sg.FlexForm('Status Window', auto_size_text=True, auto_size_buttons=False, grab_anywhere=False)
 
-    start_class = sg.Text('', size=(12, 1), font=('Helvetica', 20), background_color='black', text_color='white', justification='center')
-    
-    #Classes are placeholder names and will change
+    start_class = sg.Text('', size=(12, 1), font=('Helvetica', 20), background_color='black', text_color='white',
+                          justification='center')
+
+    # Classes are placeholder names and will change
     class_list = ['Warrior', 'Wizard', 'Rogue', 'Sword Mage', 'Mercenary', 'Sorcerer', 'All-Rounder']
 
-    layout = [[sg.Text('Name:'), sg.InputText('', key='name')],    #Layout for the status window
+    layout = [[sg.Text('Name:'), sg.InputText('', key='name')],  # Layout for the status window
               [sg.Text('_' * 55)],
               [sg.Text('Stats:')],
-              [sg.Text('STR:', size=(5, 1)), sg.Spin([i for i in range(0, 101)], initial_value=0, key='STR', size=(5, 1))],
-              [sg.Text('INT:', size=(5, 1)), sg.Spin([i for i in range(0, 101)], initial_value=0, key='INT', size=(5, 1))],
-              [sg.Text('DEX:', size=(5, 1)), sg.Spin([i for i in range(0, 101)], initial_value=0, key='DEX', size=(5, 1))],
+              [sg.Text('STR:', size=(5, 1)),
+               sg.Spin([i for i in range(0, 101)], initial_value=0, key='STR', size=(5, 1))],
+              [sg.Text('INT:', size=(5, 1)),
+               sg.Spin([i for i in range(0, 101)], initial_value=0, key='INT', size=(5, 1))],
+              [sg.Text('DEX:', size=(5, 1)),
+               sg.Spin([i for i in range(0, 101)], initial_value=0, key='DEX', size=(5, 1))],
               [sg.Text('Class:', size=(5, 1), font=('Helvetica', 20)), start_class, sg.RealtimeButton('Class Info')],
               [sg.Text(' ' * 34), sg.Exit()]]
 
@@ -24,26 +27,34 @@ def status_window():
 
     while True:
         button, values = form.ReadNonBlocking()
-        if values is None or button == 'Exit': break                        #Program ends successfully if 'Quit' is clicked or window is closed
+        if values is None or button == 'Exit': break  # Program ends successfully if 'Quit' is clicked or window is closed
 
-        #When no stat requirements are met:
+        # When no stat requirements are met:
         if all([int(values['STR']), int(values['INT']), int(values['DEX'])]) < 10: start_class.Update('')
 
-        #Classes based on one stat:
-        if int(values['STR']) == 10: start_class.Update(class_list[0])
-        elif int(values['INT']) == 10: start_class.Update(class_list[1])      #Class is displayed in window when the stat requirements are met  (stat requirements are placeholder)
-        elif int(values['DEX']) == 10: start_class.Update(class_list[2])
+        # Classes based on one stat:
+        if int(values['STR']) == 10:
+            start_class.Update(class_list[0])
+        elif int(values['INT']) == 10:
+            start_class.Update(class_list[
+                                   1])  # Class is displayed in window when the stat requirements are met  (stat requirements are placeholder)
+        elif int(values['DEX']) == 10:
+            start_class.Update(class_list[2])
 
-        #Classes based on two stats:
-        if int(values['STR']) >= 10 and int(values['INT']) >= 10: start_class.Update(class_list[3])
-        elif int(values['STR']) >= 10 and int(values['DEX']) >= 10: start_class.Update(class_list[4])
-        elif int(values['INT']) >= 10 and int(values['DEX']) >= 10: start_class.Update(class_list[5])
+        # Classes based on two stats:
+        if int(values['STR']) >= 10 and int(values['INT']) >= 10:
+            start_class.Update(class_list[3])
+        elif int(values['STR']) >= 10 and int(values['DEX']) >= 10:
+            start_class.Update(class_list[4])
+        elif int(values['INT']) >= 10 and int(values['DEX']) >= 10:
+            start_class.Update(class_list[5])
 
-        #Classes based on three stats:
-        if int(values['STR']) >= 10 and int(values['INT']) >= 10 and int(values['DEX']) >= 10: start_class.Update(class_list[6])
+        # Classes based on three stats:
+        if int(values['STR']) >= 10 and int(values['INT']) >= 10 and int(values['DEX']) >= 10: start_class.Update(
+            class_list[6])
 
-        #Class info button
+        # Class info button
         if button == 'Class Info' and start_class.DisplayText == '':
             sg.Popup('Not a Class:', 'If you see this, go back and obtain a class!')
-        if button == 'Class Info' and start_class.DisplayText == 'Warrior':         #Example of a popup display explaining the class when the button is pressed
-            sg.Popup('Warrior Class:', 'A class that specializes in melee combat')  #Placeholder descriptions
+        if button == 'Class Info' and start_class.DisplayText == 'Warrior':  # Example of a popup display explaining the class when the button is pressed
+            sg.Popup('Warrior Class:', 'A class that specializes in melee combat')  # Placeholder descriptions

--- a/StatusWindow.py
+++ b/StatusWindow.py
@@ -3,7 +3,7 @@ import PySimpleGUI as sg
 
 def status_window():
     sg.ChangeLookAndFeel('TealMono')  # Changes color scheme of window created
-    form = sg.FlexForm('Status Window', auto_size_text=True, auto_size_buttons=False, grab_anywhere=False)
+    form = sg.FlexForm('Status Window', auto_size_buttons=False, grab_anywhere=False, return_keyboard_events=True)
 
     start_class = sg.Text('', size=(12, 1), font=('Helvetica', 20), background_color='black', text_color='white',
                           justification='center')
@@ -23,38 +23,46 @@ def status_window():
               [sg.Text('Class:', size=(5, 1), font=('Helvetica', 20)), start_class, sg.RealtimeButton('Class Info')],
               [sg.Text(' ' * 34), sg.Exit()]]
 
-    form.LayoutAndRead(layout, non_blocking=True)
+    form.Layout(layout)
 
     while True:
-        button, values = form.ReadNonBlocking()
+        button, values = form.Read()
         if values is None or button == 'Exit': break  # Program ends successfully if 'Quit' is clicked or window is closed
 
         # When no stat requirements are met:
-        if all([int(values['STR']), int(values['INT']), int(values['DEX'])]) < 10: start_class.Update('')
+        try:
+            strength = int(values['STR'])
+            intel = int(values['INT'])
+            dex = int(values['DEX'])
+        except:
+            continue
+
+        if all((strength<10, intel<10, dex<10)): start_class.Update('')
 
         # Classes based on one stat:
-        if int(values['STR']) == 10:
+        if strength == 10:
             start_class.Update(class_list[0])
-        elif int(values['INT']) == 10:
-            start_class.Update(class_list[
-                                   1])  # Class is displayed in window when the stat requirements are met  (stat requirements are placeholder)
-        elif int(values['DEX']) == 10:
+        elif intel == 10:
+            start_class.Update(class_list[1])  # Class is displayed in window when the stat requirements are met  (stat requirements are placeholder)
+        elif dex == 10:
             start_class.Update(class_list[2])
 
         # Classes based on two stats:
-        if int(values['STR']) >= 10 and int(values['INT']) >= 10:
+        if strength >= 10 and intel >= 10:
             start_class.Update(class_list[3])
-        elif int(values['STR']) >= 10 and int(values['DEX']) >= 10:
+        elif strength >= 10 and dex >= 10:
             start_class.Update(class_list[4])
-        elif int(values['INT']) >= 10 and int(values['DEX']) >= 10:
+        elif intel >= 10 and dex >= 10:
             start_class.Update(class_list[5])
 
         # Classes based on three stats:
-        if int(values['STR']) >= 10 and int(values['INT']) >= 10 and int(values['DEX']) >= 10: start_class.Update(
-            class_list[6])
+        if strength >= 10 and intel >= 10 and dex >= 10: start_class.Update(class_list[6])
 
         # Class info button
         if button == 'Class Info' and start_class.DisplayText == '':
             sg.Popup('Not a Class:', 'If you see this, go back and obtain a class!')
         if button == 'Class Info' and start_class.DisplayText == 'Warrior':  # Example of a popup display explaining the class when the button is pressed
             sg.Popup('Warrior Class:', 'A class that specializes in melee combat')  # Placeholder descriptions
+
+
+status_window()

--- a/StatusWindow.py
+++ b/StatusWindow.py
@@ -3,66 +3,100 @@ import PySimpleGUI as sg
 
 def status_window():
     sg.ChangeLookAndFeel('TealMono')  # Changes color scheme of window created
-    form = sg.FlexForm('Status Window', auto_size_buttons=False, grab_anywhere=False, return_keyboard_events=True)
-
-    start_class = sg.Text('', size=(12, 1), font=('Helvetica', 20), background_color='black', text_color='white',
-                          justification='center')
+    form = sg.FlexForm('Status Window', auto_size_text=True, auto_size_buttons=False, grab_anywhere=False,
+                       return_keyboard_events=True)
 
     # Classes are placeholder names and will change
     class_list = ['Warrior', 'Wizard', 'Rogue', 'Sword Mage', 'Mercenary', 'Sorcerer', 'All-Rounder']
 
-    layout = [[sg.Text('Name:'), sg.InputText('', key='name')],  # Layout for the status window
+    istat = 5  # Initial stat value
+    # Layout for the status window
+    layout = [[sg.Text('Name:'), sg.Text('', size=(20, 1), background_color='black', text_color='white', key='cname'),
+               sg.ReadFormButton('Choose Name')],
               [sg.Text('_' * 55)],
               [sg.Text('Stats:')],
+              [sg.Text('Points Remaining'), sg.Text('15', size=(2, 1), key='points')],
               [sg.Text('STR:', size=(5, 1)),
-               sg.Spin([i for i in range(0, 101)], initial_value=0, key='STR', size=(5, 1))],
+               sg.Spin([i for i in range(5, 101)], initial_value=istat, key='STR', size=(5, 1), change_submits=True)],
               [sg.Text('INT:', size=(5, 1)),
-               sg.Spin([i for i in range(0, 101)], initial_value=0, key='INT', size=(5, 1))],
+               sg.Spin([i for i in range(5, 101)], initial_value=istat, key='INT', size=(5, 1), change_submits=True)],
               [sg.Text('DEX:', size=(5, 1)),
-               sg.Spin([i for i in range(0, 101)], initial_value=0, key='DEX', size=(5, 1))],
-              [sg.Text('Class:', size=(5, 1), font=('Helvetica', 20)), start_class, sg.RealtimeButton('Class Info')],
-              [sg.Text(' ' * 34), sg.Exit()]]
+               sg.Spin([i for i in range(5, 101)], initial_value=istat, key='DEX', size=(5, 1), change_submits=True)],
+              [sg.Text('Class:', size=(5, 1), font=('Helvetica', 20)),
+               sg.Text('', size=(13, 1), font=('Helvetica', 20), background_color='black', text_color='white',
+                       justification='center', key='class'),
+               sg.ReadFormButton('Class Info')],
+              [sg.ReadFormButton('Reset Stats'), sg.Text(' ' * 51), sg.Exit()]]
 
     form.Layout(layout)
-
+    total_points = 15
+    cur_points = 15
     while True:
         button, values = form.Read()
-        if values is None or button == 'Exit': break  # Program ends successfully if 'Quit' is clicked or window is closed
+
+        if button == 'Choose Name':  # Button to type in your name for your character
+            name = sg.PopupGetText('What is your name?')
+            form.FindElement('cname').Update(name)
+
+        if button is None or button == 'Exit': break  # Program ends successfully if 'Quit' is clicked or window is closed
 
         # When no stat requirements are met:
         try:
             strength = int(values['STR'])
             intel = int(values['INT'])
             dex = int(values['DEX'])
+            # spoints = int(values['points'])
         except:
             continue
 
-        if all((strength<10, intel<10, dex<10)): start_class.Update('')
+        if all((strength, intel, dex)) < 10: form.FindElement('class').Update('')
+
+        # How skill points remaining is determined (not sure how to stop stats from increasing when spoints = 0)
+        if 0 <= cur_points < 16:
+            stat = [strength, intel, dex]
+            if 14 < sum(stat) <= 30:
+                spoints = 15 - (sum(stat) - 15)
+                cur_points = spoints
+                form.FindElement('points').Update(spoints)
+
+        form.FindElement('STR').Update(new_values=[i for i in range(1, strength + cur_points + 1)])
+        form.FindElement('DEX').Update(new_values=[i for i in range(1, dex + cur_points + 1)])
+        form.FindElement('INT').Update(new_values=[i for i in range(1, intel + cur_points + 1)])
 
         # Classes based on one stat:
-        if strength == 10:
-            start_class.Update(class_list[0])
-        elif intel == 10:
-            start_class.Update(class_list[1])  # Class is displayed in window when the stat requirements are met  (stat requirements are placeholder)
-        elif dex == 10:
-            start_class.Update(class_list[2])
+        if strength >= 10:
+            form.FindElement('class').Update(class_list[0])
+        elif intel >= 10:
+            form.FindElement('class').Update(class_list[
+                                                 1])  # Class is displayed in window when the stat requirements are met  (stat requirements are placeholder)
+        elif dex >= 10:
+            form.FindElement('class').Update(class_list[2])
 
         # Classes based on two stats:
         if strength >= 10 and intel >= 10:
-            start_class.Update(class_list[3])
+            form.FindElement('class').Update(class_list[3])
         elif strength >= 10 and dex >= 10:
-            start_class.Update(class_list[4])
+            form.FindElement('class').Update(class_list[4])
         elif intel >= 10 and dex >= 10:
-            start_class.Update(class_list[5])
+            form.FindElement('class').Update(class_list[5])
 
         # Classes based on three stats:
-        if strength >= 10 and intel >= 10 and dex >= 10: start_class.Update(class_list[6])
+        if strength >= 10 and intel >= 10 and dex >= 10:
+            form.FindElement('class').Update(class_list[6])
+        # # Button that resets stats back initial values as well as class name
+        elif button == 'Reset Stats':
+            form.Fill({'STR': '5', 'INT': '5', 'DEX': '5'})
+            form.FindElement('points').Update(15)
+            if all((strength, intel, dex)) < 10: form.FindElement('class').Update('')
 
         # Class info button
-        if button == 'Class Info' and start_class.DisplayText == '':
+        # TODO - Need to change the use of .DisplayText
+        #       Cannot reach inside of the elements to get at their internal values like DisplayText.
+        #       Don't use GUI elements as variables.  Update the elements but don't read (at this point in time)
+        if button == 'Class Info' and form.FindElement('class').DisplayText == '':
             sg.Popup('Not a Class:', 'If you see this, go back and obtain a class!')
-        if button == 'Class Info' and start_class.DisplayText == 'Warrior':  # Example of a popup display explaining the class when the button is pressed
+        if button == 'Class Info' and form.FindElement(
+                'class').DisplayText == 'Warrior':  # Example of a popup display explaining the class when the button is pressed
             sg.Popup('Warrior Class:', 'A class that specializes in melee combat')  # Placeholder descriptions
-
 
 status_window()


### PR DESCRIPTION
… enabled return keyboard events


A number of changes... the starting code was **really well done.**.. I want to stress that.


What seems to not be clear in the documentation is that non-blocking forms do not need to be used in order to get forms that update as users interact with it.  This needs to be better documented because the performance differences are significant.  The non-blocking way is much more efficient and responsive and it's not a polled window.

I saw the conversion from string to int all over the place due to the form returning values as strings.  This should be done only once , right after the GUI returns.  This gets you out of the GUI world and into the one where your variables are in the format you want them in.. .in this case all ints.

I was getting crashes when I entered incorrect keys such as letters.  Putting the conversion into a try block removed all those crashes.


If you have questions, feel free to ask.

This was AWESOME to see and read!  Thank you for sharing.
